### PR TITLE
Fix archweb url to follow new redirection

### DIFF
--- a/archweb.inc.sh
+++ b/archweb.inc.sh
@@ -1,7 +1,7 @@
 archweb_get_pkgbase() {
   local pkgbase
 
-  pkgbase=$(curl -Gs 'https://www.archlinux.org/packages/search/json/' --data-urlencode "q=$1" |
+  pkgbase=$(curl -LGs 'https://archlinux.org/packages/search/json/' --data-urlencode "q=$1" |
       jq -r --arg pkgname "$1" 'limit(1; .results[] | select(.pkgname == $pkgname).pkgbase)')
   [[ $pkgbase ]] || return
 


### PR DESCRIPTION
```www.archlinux.org``` now redirects to ```archlinux.org```. 
Reflect that in the the ```curl``` command since it does not follow the redirect.